### PR TITLE
FIxed namespace so it's now psr-4 compliant

### DIFF
--- a/Console/Commands/AppleKeyGenerate.php
+++ b/Console/Commands/AppleKeyGenerate.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Ahilan\Apple\console\commands;
+namespace Ahilan\Apple\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;


### PR DESCRIPTION
When using this package in a laravel 8 project and php 7.4 you get the following notice:
```
Deprecation Notice: Class Ahilan\Apple\console\commands\AppleKeyGenerate located in ./vendor/ahilmurugesan/socialite-apple-helper/Console/Commands/AppleKeyGenerate.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/Cellar/composer/1.10.10/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
```

This fixes the namespaces which makes it compliant